### PR TITLE
Gratuitous use of env

### DIFF
--- a/pipeline-examples/push-git-repo/pushGitRepo.Groovy
+++ b/pipeline-examples/push-git-repo/pushGitRepo.Groovy
@@ -8,7 +8,7 @@
 withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'MyID', usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD']]) {
 
     sh("git tag -a some_tag -m 'Jenkins'")
-    sh("git push https://${env.GIT_USERNAME}:${env.GIT_PASSWORD}@<REPO> --tags")
+    sh('git push https://${GIT_USERNAME}:${GIT_PASSWORD}@<REPO> --tags')
 }
 
 // There isn't as trivial a way to override the ssh key if you want to push that


### PR DESCRIPTION
Senseless to use Groovy to substitute environment variables when the shell would do it.

@reviewbybees