### PR TITLE
Using withEnv instead of modifying env.PATH

### DIFF
--- a/pipeline-examples/maven-and-jdk-specific-version/README.md
+++ b/pipeline-examples/maven-and-jdk-specific-version/README.md
@@ -3,6 +3,8 @@
 An example showing how to build a standard maven project with specific
 versions for Maven and the JDK.
 
+It shows how to use the `withEnv` step to define the right `PATH` to use the tools.
+
 # Caveats
 
 * in `tool 'thetool'`, the `thetool` string **must** match a defined

--- a/pipeline-examples/maven-and-jdk-specific-version/mavenAndJdkSpecificVersion.groovy
+++ b/pipeline-examples/maven-and-jdk-specific-version/mavenAndJdkSpecificVersion.groovy
@@ -1,14 +1,13 @@
-
-env.JAVA_HOME = tool 'jdk-1.8.0'
 // Advice: don't define M2_HOME in general. Maven will autodetect its root fine.
-def mvnHome   = tool 'maven-3.2.1'
-env.PATH="${env.JAVA_HOME}/bin:${mvnHome}/bin:${env.PATH}"
+withEnv(["JAVA_HOME=${ tool 'jdk-1.8.0_64bits' }", "PATH+MAVEN=${tool 'maven-3.2.1'}/bin:${env.JAVA_HOME}/bin"]) {
 
-// Side Maven notes:
-// --batch-mode : recommended in CI to inform maven to not run in interactive mode (less logs)
-// -V : strongly recommended in CI, will display the JDK and Maven versions in use.
-//      Very useful to be quickly sure the selected versions were the ones you think.
-// -U : force maven to update snapshots each time (default : once an hour, makes no sense in CI).
-// -Dsurefire.useFile=false : useful in CI. Displays test errors in the logs directly (instead of
-//                            having to crawl the workspace files to see the cause).
-sh "mvn --batch-mode -V -U -e clean deploy -Dsurefire.useFile=false"
+    // Apache Maven related side notes:
+    // --batch-mode : recommended in CI to inform maven to not run in interactive mode (less logs)
+    // -V : strongly recommended in CI, will display the JDK and Maven versions in use.
+    //      Very useful to be quickly sure the selected versions were the ones you think.
+    // -U : force maven to update snapshots each time (default : once an hour, makes no sense in CI).
+    // -Dsurefire.useFile=false : useful in CI. Displays test errors in the logs directly (instead of
+    //                            having to crawl the workspace files to see the cause).
+    sh "mvn --batch-mode -V -U -e clean deploy -Dsurefire.useFile=false"
+
+}


### PR DESCRIPTION
Modified to use `withEnv` instead as advised by @daniel-beck and @jglick in https://github.com/jenkinsci/pipeline-examples/pull/15.