### PR TITLE
Add sample Jenkinsfile to show try/catch logic for pipeline

### DIFF
--- a/jenkinsfile-examples/nodejs-build-test-deploy-docker-notify/Jenkinsfile
+++ b/jenkinsfile-examples/nodejs-build-test-deploy-docker-notify/Jenkinsfile
@@ -1,5 +1,29 @@
 #!groovy
 
+/*
+The MIT License
+
+Copyright (c) 2015-, CloudBees, Inc., and a number of other of contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
 node('node') {
 
 

--- a/jenkinsfile-examples/nodejs-build-test-deploy-docker-notify/Jenkinsfile
+++ b/jenkinsfile-examples/nodejs-build-test-deploy-docker-notify/Jenkinsfile
@@ -1,0 +1,76 @@
+#!groovy
+
+node('node') {
+
+
+    def err = null
+    currentBuild.result = "SUCCESS"
+
+    try {
+
+       stage 'Checkout'
+
+            checkout scm
+
+       stage 'Test'
+
+            env.NODE_ENV = "test"
+
+            print "Environment will be : ${env.NODE_ENV}"
+
+            sh 'node -v'
+            sh 'npm prune'
+            sh 'npm install'
+            sh 'npm test'
+
+       stage 'Build Docker'
+
+            sh './dockerBuild.sh'
+
+       stage 'Deploy'
+
+            echo 'Push to Repo'
+            sh './dockerPushToRepo.sh'
+
+            echo 'ssh to web server and tell it to pull new image'
+            sh 'ssh deploy@xxxxx.xxxxx.com running/xxxxxxx/dockerRun.sh'
+
+       stage 'Cleanup'
+
+            echo 'prune and cleanup'
+            sh 'npm prune'
+            sh 'rm node_modules -rf'
+
+            mail body: 'project build successful',
+                        from: 'xxxx@yyyyy.com',
+                        replyTo: 'xxxx@yyyy.com',
+                        subject: 'project build successful',
+                        to: 'yyyyy@yyyy.com'
+
+        }
+
+
+    catch (caughtError) {
+
+        err = caughtError
+        currentBuild.result = "FAILURE"
+
+            mail body: "project build error: ${err}" ,
+            from: 'xxxx@yyyy.com',
+            replyTo: 'yyyy@yyyy.com',
+            subject: 'project build failed',
+            to: 'zzzz@yyyyy.com'
+
+        }
+
+    finally {
+
+
+        /* Must re-throw exception to propagate error */
+        if (err) {
+            throw err
+        }
+
+    }
+
+}

--- a/jenkinsfile-examples/nodejs-build-test-deploy-docker-notify/README.md
+++ b/jenkinsfile-examples/nodejs-build-test-deploy-docker-notify/README.md
@@ -1,0 +1,21 @@
+# Synopsis
+Demonstrate an example of a Jenkinsfile to build/test/deploy and notify based on results
+
+# Background
+
+A try/catch block is useful to perform specific actions based on the result of a complex pipeline. This example Jenkinsfile shows.
+- Pull from Git
+- Install nodejs
+- Build
+- Test
+- Build and push a docker container to private dockerhub
+- SSH to a server to tell it to use the new image
+- Notification by email of positive or negative results
+
+# A more detailed groovy example
+The inspiration and help on how to do this came from (https://github.com/freebsd/freebsd-ci/blob/master/scripts/build/build-test.groovy)
+
+
+
+ 
+


### PR DESCRIPTION
Sample Jenkinsfile for a nodejs project with multiple steps with a try/catch block to notify based on result.
Simulates the old "notification" scheme for a free-form job.
