### PR TITLE
Using an explicit closure param instead of it

### DIFF
--- a/pipeline-examples/trigger-job-on-all-nodes/triggerJobOnEveryNode.groovy
+++ b/pipeline-examples/trigger-job-on-all-nodes/triggerJobOnEveryNode.groovy
@@ -23,5 +23,5 @@ parallel branches
 // This method collects a list of Node names from the current Jenkins instance
 @NonCPS
 def nodeNames() {
-  return jenkins.model.Jenkins.instance.nodes.collect { it.name }
+  return jenkins.model.Jenkins.instance.nodes.collect { node -> node.name }
 }


### PR DESCRIPTION
It's probably clearer for a newcomer, and seems like some users are
having issues it that form under some circumstances. Oh well.
https://github.com/jenkinsci/pipeline-examples/commit/efac394c44489d3c308631d8868b149294df48f5#commitcomment-17609700