### PR TITLE
Update access-repo-information.groovy

### DIFF
--- a/pipeline-examples/github-org-plugin/access-repo-information.groovy
+++ b/pipeline-examples/github-org-plugin/access-repo-information.groovy
@@ -1,6 +1,10 @@
 #!groovy
 
     // github-organization-plugin jobs are named as 'org/repo/branch'
+    // we don't want to assume that the github-organization job is at the top-level
+    // instead we get the total number of tokens (size) 
+    // and work back from the branch level Pipeline job where this would actually be run
+    // Note: that branch job is at -1 because Java uses zero-based indexing
     tokens = "${env.JOB_NAME}".tokenize('/')
     org = tokens[tokens.size()-3]
     repo = tokens[tokens.size()-2]

--- a/pipeline-examples/github-org-plugin/access-repo-information.groovy
+++ b/pipeline-examples/github-org-plugin/access-repo-information.groovy
@@ -2,7 +2,7 @@
 
     // github-organization-plugin jobs are named as 'org/repo/branch'
     tokens = "${env.JOB_NAME}".tokenize('/')
-    org = tokens[0]
-    repo = tokens[1]
-    branch = tokens[2]
+    org = tokens[tokens.size()-3]
+    repo = tokens[tokens.size()-2]
+    branch = tokens[tokens.size()-1]
 


### PR DESCRIPTION
The GitHub Org Folder job may not be created at the Jenkins master top-level. Using the tokens list size and walking back from there will always provide the correct index for org, repo, and branch.