### PR TITLE
Switch Git commit example to using `sh` step and using `returnStdout`

### DIFF
--- a/pipeline-examples/gitcommit/README.md
+++ b/pipeline-examples/gitcommit/README.md
@@ -1,7 +1,10 @@
 # Synopsis
+
 Demonstrate how to expose the git_commit to a Pipeline job.
 
 # Background
 
 The git plugin exposes some environment variables to a freestyle job that are not currently exposed to a Pipeline job.
-Here's how to recover that ability using a git command and Pipeline's readFile() function.
+Here's how to recover that ability using a git command and Pipeline's [`sh`][pipeline-sh-documentation] step.
+
+[pipeline-sh-documentation]: https://jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#sh-shell-script

--- a/pipeline-examples/gitcommit/gitcommit.groovy
+++ b/pipeline-examples/gitcommit/gitcommit.groovy
@@ -2,14 +2,6 @@
 // checked out your sources on the slave. A 'git' executable
 // must be available.
 // Most typical, if you're not cloning into a sub directory
-sh('git rev-parse HEAD > GIT_COMMIT')
-git_commit=readFile('GIT_COMMIT')
+gitCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
 // short SHA, possibly better for chat notifications, etc.
-short_commit=git_commit.take(6)
-
-//create a GIT_COMMIT file in workspace and read back into a string in Pipeline
-// If you have your sources checked out in a 'src' subdir
-sh('cd src && git rev-parse HEAD > GIT_COMMIT')
-git_commit=readFile('src/GIT_COMMIT')
-// short SHA, possibly better for chat notifications, etc.
-short_commit=git_commit.take(6)
+shortCommit = gitCommit.take(6)


### PR DESCRIPTION
----

#### Notes

2.4 of the [Pipeline Nodes and Processes Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Nodes+and+Processes+Plugin) added the ability to return STDOUT from the execution.