### PR TITLE
Add build url to fail e-mail message

### DIFF
--- a/jenkinsfile-examples/nodejs-build-test-deploy-docker-notify/Jenkinsfile
+++ b/jenkinsfile-examples/nodejs-build-test-deploy-docker-notify/Jenkinsfile
@@ -77,7 +77,7 @@ node('node') {
 
         currentBuild.result = "FAILURE"
 
-            mail body: "project build error: ${err}" ,
+            mail body: "project build error is here: ${env.BUILD_URL}" ,
             from: 'xxxx@yyyy.com',
             replyTo: 'yyyy@yyyy.com',
             subject: 'project build failed',


### PR DESCRIPTION
${err} is always "hudson.AbortException: script returned exit code 2."
So, better to put direct link to build