### PR TITLE
add `return this;` to load-from-file

### DIFF
--- a/pipeline-examples/load-from-file/externalCall.groovy
+++ b/pipeline-examples/load-from-file/externalCall.groovy
@@ -2,3 +2,5 @@
 def call(String whoAreYou) {
     echo "Now we're being called more magically, ${whoAreYou}, thanks to the call(...) method."
 }
+
+return this;

--- a/pipeline-examples/load-from-file/externalMethod.groovy
+++ b/pipeline-examples/load-from-file/externalMethod.groovy
@@ -2,3 +2,5 @@
 def lookAtThis(String whoAreYou) {
     echo "Look at this, ${whoAreYou}! You loaded this from another file!"
 }
+
+return this;


### PR DESCRIPTION
with jenkins 2.19 and workflow-cps 2.13, when `load`ing a script without
`return this` at end, the result is `null`

see https://jenkins.io/doc/pipeline/steps/workflow-cps/:
   Where `pipeline.groovy` defines functionA and functionB
   functions (among others) before ending with `return this;`