### PR TITLE
Fix archiveArtifacts in sample Android Jenkinsfile

### DIFF
--- a/jenkinsfile-examples/android-build-flavor-from-branch/JenkinsFile
+++ b/jenkinsfile-examples/android-build-flavor-from-branch/JenkinsFile
@@ -19,7 +19,7 @@ node {
 
   stage 'Stage Archive'
   //tell Jenkins to archive the apks
-  step([$class: 'ArtifactArchiver', artifacts: 'App/build/outputs/apk/*.apk', fingerprint: true])
+  archiveArtifacts artifacts: 'app/build/outputs/apk/*.apk', fingerprint: true
 
   stage 'Stage Upload To Fabric'
   sh "./gradlew crashlyticsUploadDistribution${flavor}Debug  -PBUILD_NUMBER=${env.BUILD_NUMBER}"


### PR DESCRIPTION
I was banging my head against my screen. Eventually, it turns out it was caused by a case mismatch!

In Android by default the app folder is `app`, not `App`.

Another improvement here is to use `archiveArtifacts` directly instead of the class.