### PR TITLE
Update README.md to remove Script

### DIFF
--- a/jenkinsfile-examples/README.md
+++ b/jenkinsfile-examples/README.md
@@ -1,3 +1,3 @@
 # Jenkinsfile examples
 
-This directory contains example Jenkinsfiles, which are used with the Pipeline Multibranch functionality, or the Pipeline script from SCM functionality.
+This directory contains example Jenkinsfiles, which are used with the Pipeline Multibranch functionality, or the Pipeline from SCM functionality.


### PR DESCRIPTION
Pipelines may now be written in either Declarative or Scripted Pipeline syntax. Jenkinsfiles can contain either. To minimize confusion we want to remove "script" from these areas so that users aren't mislead about what is accpeted.