### PR TITLE
Missing quote character in example

### DIFF
--- a/pipeline-examples/artifactory-generic-upload-download/artifactoryGenericUploadDownload.groovy
+++ b/pipeline-examples/artifactory-generic-upload-download/artifactoryGenericUploadDownload.groovy
@@ -10,7 +10,7 @@ node {
             "files": [
                 {
                     "pattern": "libs-snapshot-local/*.zip",
-                    "target": "dependencies/,
+                    "target": "dependencies/",
                     "props": "p1=v1;p2=v2"
                 }
             ]


### PR DESCRIPTION
Missing quote character in the "artifactory-generic-upload-download" example.