### PR TITLE
stages now use block arguments as per new requirements.

### DIFF
--- a/jenkinsfile-examples/nodejs-build-test-deploy-docker-notify/Jenkinsfile
+++ b/jenkinsfile-examples/nodejs-build-test-deploy-docker-notify/Jenkinsfile
@@ -31,48 +31,55 @@ node('node') {
 
     try {
 
-       stage 'Checkout'
+       stage('Checkout'){
 
-            checkout scm
+          checkout scm
+       }
 
-       stage 'Test'
+       stage('Test'){
 
-            env.NODE_ENV = "test"
+         env.NODE_ENV = "test"
 
-            print "Environment will be : ${env.NODE_ENV}"
+         print "Environment will be : ${env.NODE_ENV}"
 
-            sh 'node -v'
-            sh 'npm prune'
-            sh 'npm install'
-            sh 'npm test'
+         sh 'node -v'
+         sh 'npm prune'
+         sh 'npm install'
+         sh 'npm test'
 
-       stage 'Build Docker'
+       }
+
+       stage('Build Docker'){
 
             sh './dockerBuild.sh'
+       }
 
-       stage 'Deploy'
+       stage('Deploy'){
 
-            echo 'Push to Repo'
-            sh './dockerPushToRepo.sh'
+         echo 'Push to Repo'
+         sh './dockerPushToRepo.sh'
 
-            echo 'ssh to web server and tell it to pull new image'
-            sh 'ssh deploy@xxxxx.xxxxx.com running/xxxxxxx/dockerRun.sh'
+         echo 'ssh to web server and tell it to pull new image'
+         sh 'ssh deploy@xxxxx.xxxxx.com running/xxxxxxx/dockerRun.sh'
 
-       stage 'Cleanup'
+       }
 
-            echo 'prune and cleanup'
-            sh 'npm prune'
-            sh 'rm node_modules -rf'
+       stage('Cleanup'){
 
-            mail body: 'project build successful',
-                        from: 'xxxx@yyyyy.com',
-                        replyTo: 'xxxx@yyyy.com',
-                        subject: 'project build successful',
-                        to: 'yyyyy@yyyy.com'
+         echo 'prune and cleanup'
+         sh 'npm prune'
+         sh 'rm node_modules -rf'
 
-        }
+         mail body: 'project build successful',
+                     from: 'xxxx@yyyyy.com',
+                     replyTo: 'xxxx@yyyy.com',
+                     subject: 'project build successful',
+                     to: 'yyyyy@yyyy.com'
+       }
 
 
+
+    }
     catch (err) {
 
         currentBuild.result = "FAILURE"


### PR DESCRIPTION
I believe the syntax for pipeline has changed.  This change should avoid getting the following message: 

> Using the ‘stage’ step without a block argument is deprecated

Any thoughts?