### PR TITLE
Add example of 'sh' step to retrieve changeset

### DIFF
--- a/pipeline-examples/gitcommit_changeset/README.md
+++ b/pipeline-examples/gitcommit_changeset/README.md
@@ -1,0 +1,4 @@
+# Synopsis
+
+Demonstrate how to retrieve the changeset associated with a git commit to a Pipeline job.
+

--- a/pipeline-examples/gitcommit_changeset/gitcommit_changeset.groovy
+++ b/pipeline-examples/gitcommit_changeset/gitcommit_changeset.groovy
@@ -1,0 +1,9 @@
+// This should be performed at the point where you've
+// checked out your sources on the agent. A 'git' executable
+// must be available.
+// Most typical, if you're not cloning into a sub directory
+// and invoke this in the context of a directory with .git/
+// Along with SHA-1 id of the commit, it will be useful to retrieve changeset associated with that commit
+// This command results in output indicating several one of these and the affected files:
+// Added (A), Copied (C), Deleted (D), Modified (M), Renamed (R)
+commitChangeset = sh(returnStdout: true, script: 'git diff-tree --no-commit-id --name-status -r HEAD').trim()


### PR DESCRIPTION
'sh' step assists to extract list of artifacts that constituted the commit on the given branch which has been used to checkout sources in the pipeline script.