### PR TITLE
Format configfile-provider-plugin README.md

### DIFF
--- a/pipeline-examples/configfile-provider-plugin/README.md
+++ b/pipeline-examples/configfile-provider-plugin/README.md
@@ -1,4 +1,4 @@
-[configFile Provider plugin] (https://plugins.jenkins.io/config-file-provider) enables provisioning of various types of configuration files. Plugin works in such a way as to make the configuration available for the entire duration of the build across all the build agents that are used to execute the build.
+[configFile Provider plugin](https://plugins.jenkins.io/config-file-provider) enables provisioning of various types of configuration files. Plugin works in such a way as to make the configuration available for the entire duration of the build across all the build agents that are used to execute the build.
 
 Common scenarios that demand the usage of configuration files:
 


### PR DESCRIPTION
This allows a proper link to be rendered: https://jenkins.io/doc/pipeline/examples/#configfile-provider-plugin