### PR TITLE
Use standard git log command for short commit sha

### DIFF
--- a/pipeline-examples/gitcommit/gitcommit.groovy
+++ b/pipeline-examples/gitcommit/gitcommit.groovy
@@ -2,6 +2,4 @@
 // checked out your sources on the agent. A 'git' executable
 // must be available.
 // Most typical, if you're not cloning into a sub directory
-gitCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
-// short SHA, possibly better for chat notifications, etc.
-shortCommit = gitCommit.take(6)
+shortCommit = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()


### PR DESCRIPTION
- Long-lived repositories may need more than 6 leading characters to be unique. 
- Use a standard git command to cover all use cases.