### PR TITLE
Add example showing how to build project inside docker container

### DIFF
--- a/pipeline-examples/build-in-docker-container/BuildInDockerContainer.groovy
+++ b/pipeline-examples/build-in-docker-container/BuildInDockerContainer.groovy
@@ -1,0 +1,18 @@
+node {
+    stage('checkout') {
+        git url: 'https://repository.com/foo/golang-project.git'
+    }
+    stage("build") {
+        writeFile file: "test.txt", text: "test"
+        docker.withRegistry("https://my-private-registry.intranet.net", 'docker-registry-credentials') {
+            docker.image("my-private-registry.intranet.net/tool/golang").inside("-v /mount_something_from_host:/mounted") { c ->
+                sh 'cat /mounted' // we can mount any file from host
+                sh 'cat test.txt' // we can access files from workspace
+                sh 'echo "modified-inside-container" > test.txt' // we can modify files in workspace
+                sh 'go build' // we can run command from docker image
+                sh 'printenv' // jenkins is passing all envs variables into container
+            }
+        }
+        sh 'cat test.txt' // will be "modified-inside-container" here
+    }
+}

--- a/pipeline-examples/build-in-docker-container/BuildInDockerContainer.groovy
+++ b/pipeline-examples/build-in-docker-container/BuildInDockerContainer.groovy
@@ -5,8 +5,8 @@ node {
     stage("build") {
         writeFile file: "test.txt", text: "test"
         docker.withRegistry("https://my-private-registry.intranet.net", 'docker-registry-credentials') {
-            docker.image("my-private-registry.intranet.net/tool/golang").inside("-v /mount_something_from_host:/mounted") { c ->
-                sh 'cat /mounted' // we can mount any file from host
+            docker.image("my-private-registry.intranet.net/tool/golang").inside("-v /home/jenkins/foo.txt:/foo.txt") { c ->
+                sh 'cat /foo.txt' // we can mount any file from host
                 sh 'cat test.txt' // we can access files from workspace
                 sh 'echo "modified-inside-container" > test.txt' // we can modify files in workspace
                 sh 'go build' // we can run command from docker image

--- a/pipeline-examples/build-in-docker-container/README.md
+++ b/pipeline-examples/build-in-docker-container/README.md
@@ -1,0 +1,6 @@
+# Synopsis
+
+This is very simple example showing how to build project inside docker container using image coming from private docker registry.
+
+docker-registry-credentials is credentials id configured as username/password in jenkins.
+


### PR DESCRIPTION
Added very basic example showing possibilities related to using this feature: https://jenkins.io/doc/book/pipeline/docker/ 

This example is showing power of jenkins with docker in context of building project inside container.

I think adding it to https://jenkins.io/doc/pipeline/examples/ is good idea because it's showing useful features and that docs site is usually first site where new jenkins users are starting to learn pipelines.