### PR TITLE
Add msbuild executable name

### DIFF
--- a/jenkinsfile-examples/msbuild/Jenkinsfile
+++ b/jenkinsfile-examples/msbuild/Jenkinsfile
@@ -4,7 +4,7 @@ node {
 
 	stage 'Build'
 		bat 'nuget restore SolutionName.sln'
-		bat "\"${tool 'MSBuild'}\" SolutionName.sln /p:Configuration=Release /p:Platform=\"Any CPU\" /p:ProductVersion=1.0.0.${env.BUILD_NUMBER}"
+		bat "\"${tool 'MSBuild'}\\msbuild.exe\" SolutionName.sln /p:Configuration=Release /p:Platform=\"Any CPU\" /p:ProductVersion=1.0.0.${env.BUILD_NUMBER}"
 
 	stage 'Archive'
 		archive 'ProjectName/bin/Release/**'


### PR DESCRIPTION
From direct testing and from Msbuild plugin page (https://plugins.jenkins.io/msbuild): 
"Usage
To use this plugin, specify the location directory of MSBuild.exe on Jenkin's configuration page."

The command will work if full path to executable is included in the msbuild configuration, but then in that case a msbuild step in a freestyle job will not work.