### PR TITLE
fetch port number of the running container and port on the host

### DIFF
--- a/declarative-examples/simple-examples/dockercontainerPort.groovy
+++ b/declarative-examples/simple-examples/dockercontainerPort.groovy
@@ -1,0 +1,60 @@
+pipeline {
+    agent any
+
+    options {
+        timestamps()
+    }
+
+    environment {
+        IMAGE = "custom-tutum"
+    }
+
+    stages {
+        stage('prep') {
+            steps {
+                script {
+                    env.GIT_HASH = sh(
+                        script: "git show --oneline | head -1 | cut -d' ' -f1",
+                        returnStdout: true
+                    ).trim()
+                }
+            }
+        }
+        stage('build') {
+            steps {
+                script {
+                    image = docker.build("${IMAGE}")
+                    println "Newly generated image, " + image.id
+                }
+            }
+        }
+        stage('test') {
+            steps {
+                script {
+                    // https://hub.docker.com/r/tutum/hello-world/
+                    def container = image.run('-p 80')
+                    def contport = container.port(80)
+                    def resp = sh(returnStdout: true,
+                                        script: """
+                                                set -x
+                                                curl -w "%{http_code}" -o /dev/null -s \
+                                                http://\"${contport}\"
+                                                """
+                                        ).trim()
+                    if ( resp == "200" ) {
+                        println "tutum hello world is alive and kicking!"
+                        currentBuild.result = "SUCCESS"
+                    } else {
+                        println "Humans are mortals."
+                        currentBuild.result = "FAILURE"
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            cleanWs()
+        }
+    }
+}


### PR DESCRIPTION
Reference image used, https://hub.docker.com/r/tutum/hello-world/

This pipeline code snippet will (though Dockerfile is not supported which is two lines of code) fetch tutum/hello-world image, build it, start a new container based on it at port 80, will fetch host port that maps to the port of the running container, and run curl on the port of the localhost to check HTTP response.