### PR TITLE
added pipeline script for Hangouts Chat

### DIFF
--- a/pipeline-examples/hangoutsChatNotify/README.md
+++ b/pipeline-examples/hangoutsChatNotify/README.md
@@ -1,0 +1,10 @@
+# Synopsis
+Use a Hangouts Chat webhook to send an arbitrary message.
+
+# Background
+Using a combination of groovy and curl from shell, send a message to Hangouts Chat for notifications.
+Some of the more friendly groovy http libs like HTTPBuilder are not easily available. However,
+we can use groovy's built in json handling to build up the request and ship it to a command
+line curl easily enough.
+
+This will require that you configure a webhook integration in Hangouts Chat (not the Jenkins specific configuration.)

--- a/pipeline-examples/hangoutsChatNotify/hangoutsChatNotify.groovy
+++ b/pipeline-examples/hangoutsChatNotify/hangoutsChatNotify.groovy
@@ -1,0 +1,9 @@
+import groovy.json.JsonOutput
+// Add whichever params you think you'd most want to have
+// replace the chatURL below with the hook url provided by
+// Hangouts when you configure the webhook
+def notifyHangoutsChat(text) {
+    def chatURL = 'https://chat.googleapis.com/v1/spaces/xxxxxxx/messages?key=API_KEY'
+    def payload = JsonOutput.toJson([text      : text])
+    sh "curl -X POST ${chatURL} \ -H 'Content-Type: application/json' \ -d '${payload}'"
+}


### PR DESCRIPTION
added pipeline script for Hangouts Chat.
This will enable the sending of messages from build pipeline to a Hangouts chat via the webhook.