### PR TITLE
[JENKINS-55758] Use whitelisted APIs from workflow-support 2.22

### DIFF
--- a/pipeline-examples/get-build-cause/getBuildCause.groovy
+++ b/pipeline-examples/get-build-cause/getBuildCause.groovy
@@ -1,15 +1,25 @@
-// There is no direct access to the build Causes from the Pipeline, but you can
-// get this by using the `currentBuild.rawBuild` variable, as shown below.
+// As of Pipeline Supporting APIs v2.22, there is a whitelisted API to access
+// build causes as JSON that is available inside of the Pipeline Sandbox.
 
 // Get all Causes for the current build
-def causes = currentBuild.rawBuild.getCauses()
+def causes = currentBuild.getBuildCauses()
 
 // Get a specific Cause type (in this case the user who kicked off the build),
 // if present.
-def specificCause = currentBuild.rawBuild.getCause(hudson.model.Cause$UserIdCause)
+def specificCause = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')
 
-// If you see errors regarding 'Scripts not permitted to use method...' approve 
-// these scripts at JENKINS_URL/scriptApproval/ - the UI shows the blocked methods 
-
-// See the Javadoc for Cause for more information on what's in Causes, etc at:
-// http://javadoc.jenkins-ci.org/hudson/model/class-use/Cause.html
+// The JSON data is created by calling methods annotated with `@Exported` for
+// each Cause type. See the Javadoc for specific Cause types to check exactly
+// what data will be available.
+// For example, for a build triggered manually by a specific user, the resulting
+// JSON would be something like the following:
+//
+// [
+//  { 
+//    "_class\": "hudson.model.Cause$UserIdCause",
+//    "shortDescription": "Started by user anonymous",
+//    "userId": "tester",
+//    "userName": "anonymous"
+//  }
+// ]
+// cf. https://javadoc.jenkins-ci.org/hudson/model/Cause.UserIdCause.html


### PR DESCRIPTION
See [JENKINS-55758](https://issues.jenkins-ci.org/browse/JENKINS-55758), where a user was mislead by this outdated documentation.