### PR TITLE
Fix variable interpolation on different examples

### DIFF
--- a/declarative-examples/jenkinsfile-examples/mavenDocker.groovy
+++ b/declarative-examples/jenkinsfile-examples/mavenDocker.groovy
@@ -85,11 +85,11 @@ pipeline {
          * Multiline strings can be used for larger scripts. It is also possible to put scripts in your shared library
          * and load them with 'libaryResource'
          */
-        sh """
+        sh '''
           docker build -t ${IMAGE} .
           docker tag ${IMAGE} ${IMAGE}:${VERSION}
           docker push ${IMAGE}:${VERSION}
-        """
+        '''
       }
     }
   }

--- a/jenkinsfile-examples/android-build-flavor-from-branch/JenkinsFile
+++ b/jenkinsfile-examples/android-build-flavor-from-branch/JenkinsFile
@@ -15,14 +15,14 @@ node {
   echo "Building flavor ${flavor}"
 
   //build your gradle flavor, passes the current build number as a parameter to gradle
-  sh './gradlew clean assemble${flavor}Debug -PBUILD_NUMBER=${env.BUILD_NUMBER}'
+  sh './gradlew clean assemble${flavor}Debug -PBUILD_NUMBER=${BUILD_NUMBER}'
 
   stage 'Stage Archive'
   //tell Jenkins to archive the apks
   archiveArtifacts artifacts: 'app/build/outputs/apk/*.apk', fingerprint: true
 
   stage 'Stage Upload To Fabric'
-  sh './gradlew crashlyticsUploadDistribution${flavor}Debug  -PBUILD_NUMBER=${env.BUILD_NUMBER}'
+  sh './gradlew crashlyticsUploadDistribution${flavor}Debug  -PBUILD_NUMBER=${BUILD_NUMBER}'
 }
 
 // Pulls the android flavor out of the branch name the branch is prepended with /QA_

--- a/jenkinsfile-examples/android-build-flavor-from-branch/JenkinsFile
+++ b/jenkinsfile-examples/android-build-flavor-from-branch/JenkinsFile
@@ -15,14 +15,14 @@ node {
   echo "Building flavor ${flavor}"
 
   //build your gradle flavor, passes the current build number as a parameter to gradle
-  sh "./gradlew clean assemble${flavor}Debug -PBUILD_NUMBER=${env.BUILD_NUMBER}"
+  sh './gradlew clean assemble${flavor}Debug -PBUILD_NUMBER=${env.BUILD_NUMBER}'
 
   stage 'Stage Archive'
   //tell Jenkins to archive the apks
   archiveArtifacts artifacts: 'app/build/outputs/apk/*.apk', fingerprint: true
 
   stage 'Stage Upload To Fabric'
-  sh "./gradlew crashlyticsUploadDistribution${flavor}Debug  -PBUILD_NUMBER=${env.BUILD_NUMBER}"
+  sh './gradlew crashlyticsUploadDistribution${flavor}Debug  -PBUILD_NUMBER=${env.BUILD_NUMBER}'
 }
 
 // Pulls the android flavor out of the branch name the branch is prepended with /QA_

--- a/jenkinsfile-examples/msbuild/Jenkinsfile
+++ b/jenkinsfile-examples/msbuild/Jenkinsfile
@@ -4,8 +4,11 @@ node {
 
 	stage 'Build'
 		bat 'nuget restore SolutionName.sln'
-		bat '\"${tool \'MSBuild\'}\" SolutionName.sln /p:Configuration=Release /p:Platform=\"Any CPU\" /p:ProductVersion=1.0.0.${env.BUILD_NUMBER}'
-
+		bat """
+			setlocal enabledelayedexpansion
+			\"${tool 'MSBuild'}\" SolutionName.sln /p:Configuration=Release /p:Platform=\"Any CPU\" /p:ProductVersion=1.0.0.!BUILD_NUMBER!
+			endlocal
+		"""
 	stage 'Archive'
 		archive 'ProjectName/bin/Release/**'
 

--- a/jenkinsfile-examples/msbuild/Jenkinsfile
+++ b/jenkinsfile-examples/msbuild/Jenkinsfile
@@ -4,7 +4,7 @@ node {
 
 	stage 'Build'
 		bat 'nuget restore SolutionName.sln'
-		bat "\"${tool 'MSBuild'}\" SolutionName.sln /p:Configuration=Release /p:Platform=\"Any CPU\" /p:ProductVersion=1.0.0.${env.BUILD_NUMBER}"
+		bat '\"${tool \'MSBuild\'}\" SolutionName.sln /p:Configuration=Release /p:Platform=\"Any CPU\" /p:ProductVersion=1.0.0.${env.BUILD_NUMBER}'
 
 	stage 'Archive'
 		archive 'ProjectName/bin/Release/**'

--- a/pipeline-examples/configfile-provider-plugin/configFileProvider.groovy
+++ b/pipeline-examples/configfile-provider-plugin/configFileProvider.groovy
@@ -15,7 +15,7 @@ node {
         // via 'name' given for the field, 'variable:'
         configFileProvider([configFile(fileId: mycfg_file, variable: 'PACKER_OPTIONS')]) {
             echo " =========== ^^^^^^^^^^^^ Reading config from pipeline script "
-            sh "cat ${env.PACKER_OPTIONS}"
+            sh 'cat ${env.PACKER_OPTIONS}'
             echo " =========== ~~~~~~~~~~~~ ============ "
  
             // Access to config file opens up other possibilities like
@@ -23,7 +23,7 @@ node {
             // for example, to set generic options that can be used for generating 
             // binary images using packer.
             echo " =========== ^^^^^^^^^^^^ Reading config via Python... "
-            sh "python build_image.py ${env.PACKER_OPTIONS}"
+            sh 'python build_image.py ${env.PACKER_OPTIONS}'
             echo " =========== ~~~~~~~~~~~~ ============ "
         }
     }

--- a/pipeline-examples/configfile-provider-plugin/configFileProvider.groovy
+++ b/pipeline-examples/configfile-provider-plugin/configFileProvider.groovy
@@ -15,7 +15,7 @@ node {
         // via 'name' given for the field, 'variable:'
         configFileProvider([configFile(fileId: mycfg_file, variable: 'PACKER_OPTIONS')]) {
             echo " =========== ^^^^^^^^^^^^ Reading config from pipeline script "
-            sh 'cat ${env.PACKER_OPTIONS}'
+            sh 'cat ${PACKER_OPTIONS}'
             echo " =========== ~~~~~~~~~~~~ ============ "
  
             // Access to config file opens up other possibilities like
@@ -23,7 +23,7 @@ node {
             // for example, to set generic options that can be used for generating 
             // binary images using packer.
             echo " =========== ^^^^^^^^^^^^ Reading config via Python... "
-            sh 'python build_image.py ${env.PACKER_OPTIONS}'
+            sh 'python build_image.py ${PACKER_OPTIONS}'
             echo " =========== ~~~~~~~~~~~~ ============ "
         }
     }

--- a/pipeline-examples/slacknotify/slackNotify.groovy
+++ b/pipeline-examples/slacknotify/slackNotify.groovy
@@ -8,5 +8,7 @@ def notifySlack(text, channel) {
                                      channel   : channel,
                                      username  : "jenkins",
                                      icon_emoji: ":jenkins:"])
-    sh 'curl -X POST --data-urlencode \'payload=${payload}\' ${slackURL}'s
+    withEnv(["PAYLOAD=${payload}", "SLACK_URL=${slackURL}"]) {
+        sh 'curl -X POST --data-urlencode "payload=$PAYLOAD" $SLACK_URL'
+    }
 }

--- a/pipeline-examples/slacknotify/slackNotify.groovy
+++ b/pipeline-examples/slacknotify/slackNotify.groovy
@@ -8,5 +8,5 @@ def notifySlack(text, channel) {
                                      channel   : channel,
                                      username  : "jenkins",
                                      icon_emoji: ":jenkins:"])
-    sh "curl -X POST --data-urlencode \'payload=${payload}\' ${slackURL}"
+    sh 'curl -X POST --data-urlencode \'payload=${payload}\' ${slackURL}'s
 }

--- a/pipeline-examples/unstash-different-dir/unstashDifferentDir.groovy
+++ b/pipeline-examples/unstash-different-dir/unstashDifferentDir.groovy
@@ -28,8 +28,8 @@ node('second-node') {
 
     // Look, no output directory under the root!
     // pwd() outputs the current directory Pipeline is running in.
-    sh "ls -la ${pwd()}"
+    sh 'ls -la ${pwd()}'
 
     // And look, output directory is there under first-stash!
-    sh "ls -la ${pwd()}/first-stash"
+    sh 'ls -la ${pwd()}/first-stash'
 }

--- a/pipeline-examples/unstash-different-dir/unstashDifferentDir.groovy
+++ b/pipeline-examples/unstash-different-dir/unstashDifferentDir.groovy
@@ -27,9 +27,9 @@ node('second-node') {
     }
 
     // Look, no output directory under the root!
-    // pwd() outputs the current directory Pipeline is running in.
-    sh 'ls -la ${pwd()}'
+    // PWD outputs the current directory Pipeline is running in.
+    sh 'ls -la ${PWD}'
 
     // And look, output directory is there under first-stash!
-    sh 'ls -la ${pwd()}/first-stash'
+    sh 'ls -la ${PWD}/first-stash'
 }


### PR DESCRIPTION
I noticed that we have many incorrect examples of how to use Groovy string interpolation on the [Pipeline Examples](https://www.jenkins.io/doc/pipeline/examples/) page.

To prevent spreading this common mistake, it would be better to correct it.

See [this documentation](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#injection-via-interpolation) for more context.